### PR TITLE
update patchelf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 PORTNAME=	julia
 PORTVERSION=	0.6.3
 DISTVERSIONSUFFIX=	-full
+PORTREVISION=	1
 CATEGORIES=	lang math
 MASTER_SITES=	https://github.com/JuliaLang/julia/releases/download/v${PORTVERSION}/
 

--- a/files/patch-Make.inc
+++ b/files/patch-Make.inc
@@ -1,6 +1,6 @@
---- Make.inc.orig	2017-06-19 17:48:45 UTC
+--- Make.inc.orig	2018-05-27 21:19:34 UTC
 +++ Make.inc
-@@ -133,12 +133,7 @@ endif
+@@ -134,12 +134,7 @@ endif
  # disable automatic Makefile rules
  .SUFFIXES:
  
@@ -13,7 +13,7 @@
  
  # Julia's Semantic Versioning system labels the three decimal places in a version number as
  # the major, minor and patch versions.  Typically the major version would be incremented
-@@ -183,7 +178,7 @@ libdir := $(prefix)/lib
+@@ -184,7 +179,7 @@ libdir := $(prefix)/lib
  libexecdir := $(prefix)/libexec
  datarootdir := $(prefix)/share
  docdir := $(datarootdir)/doc/julia
@@ -22,7 +22,7 @@
  man1dir := $(mandir)/man1
  includedir := $(prefix)/include
  sysconfdir := $(prefix)/etc
-@@ -197,7 +192,7 @@ build_libdir := $(build_prefix)/lib
+@@ -198,7 +193,7 @@ build_libdir := $(build_prefix)/lib
  build_libexecdir := $(build_prefix)/libexec
  build_datarootdir := $(build_prefix)/share
  build_docdir := $(build_datarootdir)/doc/julia
@@ -31,7 +31,7 @@
  build_man1dir := $(build_mandir)/man1
  build_includedir := $(build_prefix)/include
  build_sysconfdir := $(build_prefix)/etc
-@@ -350,7 +345,7 @@ endif
+@@ -351,7 +346,7 @@ endif
  ifeq ($(USEIFC), 1)
  FC := ifort
  else
@@ -40,7 +40,7 @@
  endif
  
  STDLIBCPP_FLAG :=
-@@ -403,14 +398,14 @@ SHIPFLAGS := -O3 -ggdb2 -falign-functions
+@@ -404,14 +399,14 @@ SHIPFLAGS := -O3 -ggdb2 -falign-functions
  endif
  
  ifeq ($(USECLANG),1)

--- a/files/patch-Makefile
+++ b/files/patch-Makefile
@@ -1,6 +1,6 @@
---- Makefile.orig	2017-06-19 17:48:45 UTC
+--- Makefile.orig	2018-05-27 21:19:34 UTC
 +++ Makefile
-@@ -71,7 +71,6 @@ $(build_prefix)/.examples: $(wildcard $(
+@@ -71,7 +71,6 @@ $(build_prefix)/.examples: $(wildcard $(JULIAHOME)/exa
  	@mkdir -p $(build_docdir)/examples
  	@cp -R $(JULIAHOME)/examples/*.jl $(build_docdir)/examples/
  	@cp -R $(JULIAHOME)/examples/clustermanager $(build_docdir)/examples/
@@ -8,7 +8,7 @@
  	@echo 1 > $@
  
  julia-symlink: julia-ui-$(JULIA_BUILD_MODE)
-@@ -96,7 +95,7 @@ julia-src-release julia-src-debug : juli
+@@ -96,7 +95,7 @@ julia-src-release julia-src-debug : julia-src-% : juli
  julia-ui-release julia-ui-debug : julia-ui-% : julia-src-%
  	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/ui julia-$*
  
@@ -17,7 +17,7 @@
  	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/inference.ji JULIA_BUILD_MODE=$(JULIA_BUILD_MODE)
  
  ifneq ($(CPUID_SPECIFIC_BINARIES), 0)
-@@ -332,7 +331,7 @@ define stringreplace
+@@ -333,7 +332,7 @@ define stringreplace
  	$(build_depsbindir)/stringreplace $$(strings -t x - $1 | grep '$2' | awk '{print $$1;}') '$3' 255 "$(call cygpath_w,$1)"
  endef
  
@@ -26,7 +26,7 @@
  	@$(MAKE) $(QUIET_MAKE) all
  	@for subdir in $(bindir) $(datarootdir)/julia/site/$(VERSDIR) $(docdir) $(man1dir) $(includedir)/julia $(libdir) $(private_libdir) $(sysconfdir); do \
  		mkdir -p $(DESTDIR)$$subdir; \
-@@ -377,9 +376,6 @@ endif
+@@ -378,9 +377,6 @@ endif
  	$(INSTALL_M) $(JULIAHOME)/contrib/build_sysimg.jl $(DESTDIR)$(datarootdir)/julia/
  	# Copy in all .jl sources as well
  	cp -R -L $(build_datarootdir)/julia $(DESTDIR)$(datarootdir)/
@@ -36,7 +36,7 @@
  	# Remove perf suite
  	-rm -rf $(DESTDIR)$(datarootdir)/julia/test/perf/
  	# Remove various files which should not be installed
-@@ -387,38 +383,44 @@ endif
+@@ -388,37 +384,43 @@ endif
  	-rm -f $(DESTDIR)$(datarootdir)/julia/test/Makefile
  	# Copy in beautiful new man page
  	$(INSTALL_F) $(build_man1dir)/julia.1 $(DESTDIR)$(man1dir)/
@@ -63,7 +63,8 @@
 -else ifneq (,$(findstring $(OS),Linux FreeBSD))
 +else
  	for julia in $(DESTDIR)$(bindir)/julia* ; do \
- 		patchelf --set-rpath '$$ORIGIN/$(private_libdir_rel):$$ORIGIN/$(libdir_rel)' $$julia; \
+-		patchelf --set-rpath '$$ORIGIN/$(private_libdir_rel):$$ORIGIN/$(libdir_rel)' $$julia; \
++		patchelf --set-rpath '$(GCCPATH):$$ORIGIN/$(private_libdir_rel):$$ORIGIN/$(libdir_rel)' $$julia; \
  	done
  endif
 -
@@ -74,7 +75,7 @@
  
  	mkdir -p $(DESTDIR)$(sysconfdir)
  	cp -R $(build_sysconfdir)/julia $(DESTDIR)$(sysconfdir)/
- 
++
 +install-docs:
 +	# Copy documentation
 +	cp -R -L $(BUILDROOT)/doc/_build/html $(DESTDIR)$(docdir)/
@@ -94,7 +95,6 @@
 +	# Install appdata file
 +	mkdir -p $(DESTDIR)$(datarootdir)/appdata/
 +	$(INSTALL_F) $(JULIAHOME)/contrib/julia.appdata.xml $(DESTDIR)$(datarootdir)/appdata/
-+
+ 
  distclean dist-clean:
  	-rm -fr $(BUILDROOT)/julia-*.tar.gz $(BUILDROOT)/julia*.exe $(BUILDROOT)/julia-*.7z $(BUILDROOT)/julia-$(JULIA_COMMIT)
- 

--- a/files/patch-src_Makefile
+++ b/files/patch-src_Makefile
@@ -1,4 +1,4 @@
---- src/Makefile.orig	2017-06-19 17:48:45 UTC
+--- src/Makefile.orig	2018-05-07 22:05:07 UTC
 +++ src/Makefile
 @@ -263,7 +263,7 @@ else
  endif
@@ -9,7 +9,7 @@
  	$(INSTALL_NAME_CMD)libjulia-debug.$(SHLIB_EXT) $@
  ifneq ($(OS), WINNT)
  	@ln -sf libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT) $(build_shlibdir)/libjulia-debug.$(JL_MAJOR_SHLIB_EXT)
-@@ -278,7 +278,7 @@ $(BUILDDIR)/libjulia-debug.a: $(SRCDIR)/
+@@ -278,7 +278,7 @@ $(BUILDDIR)/libjulia-debug.a: $(SRCDIR)/julia.expmap $
  libjulia-debug: $(build_shlibdir)/libjulia-debug.$(JL_MAJOR_MINOR_SHLIB_EXT) $(PUBLIC_HEADER_TARGETS)
  
  $(build_shlibdir)/libjulia.$(JL_MAJOR_MINOR_SHLIB_EXT): $(SRCDIR)/julia.expmap $(OBJS) $(BUILDDIR)/flisp/libflisp.a $(BUILDDIR)/support/libsupport.a $(LIBUV)


### PR DESCRIPTION
Reported by user:
on the startup of `julia`
```
WARNING: Error during initialization of module LinAlg:
ErrorException("could not load library "libopenblasp"
/lib/libgcc_s.so.1: version GCC_4.6.0 required by /usr/local/lib/gcc6/libgfortran.so.3 not found")
WARNING: Error during initialization of module CHOLMOD:
ErrorException|"could not load library "libcholmod"
/usr/local/lib/libcholmod.so.1: Undefined symbol "colamd_printf"")
```

FreeBSD PR: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=228993